### PR TITLE
add support for Azure Databricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Check the <a href="themes/">themes folder</a>.
 ## Features
 The following features are supported:
 
+- [x] 1.2.0 Added URL pattern match for Azure Databricks domains.
 - [x] 1.1.0 Scroll on hover of the Table of contents.
 - [x] 1.1.0 Ability to disable Table of contents.
 - [x] 1.0.0 Style sheet support.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -9,7 +9,7 @@
     },
     "content_scripts": [
         {
-            "matches": [ "https://*.cloud.databricks.com/*" ],
+            "matches": [ "https://*.cloud.databricks.com/*", "https://*.azuredatabricks.net/*" ],
             "js": [
                 "content/utils.js",
                 "content/stylesheet.js",

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Databricks Power Tools",
     "description": "Adds features to Databricks: table of contents and a stylesheet.",
-    "version": "1.1.4",
+    "version": "1.2.0",
     "icons": {
         "128": "resources/icon_small.png",
         "512": "resources/icon.png"


### PR DESCRIPTION
Thanks for making this extension! ToC is awesome.

Currently URL list only has AWS Databricks.  
This PR adds url match for Azure Databricks domains too,
which are in form `https://*.azuredatabricks.net/*`

, for example,

> https://eastus2.azuredatabricks.net/?o=1234567893321727

