### PR TITLE
make autocomplete box not truncate

### DIFF
--- a/themes/keestalkstech.css
+++ b/themes/keestalkstech.css
@@ -51,3 +51,9 @@
 .CodeMirror-line span {
     color: black;
 }
+
+/* make autocomplete box not truncate */
+ul.CodeMirror-hints .CodeMirror-hint.jedi .display-text {
+    max-width: initial;
+}
+


### PR DESCRIPTION
Adds some css to prevent autocomplete box from being truncated at 400px, which is the default for some reason. Not sure it belongs in themes.

Before:

![image](https://user-images.githubusercontent.com/8692680/110247113-d3b44600-7f6a-11eb-9ee9-e8f636b1f1d3.png)

After:

![image](https://user-images.githubusercontent.com/8692680/110247034-5f79a280-7f6a-11eb-88ca-50fa69257d3c.png)
